### PR TITLE
Updated README and added Python 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Suppose you have a voxelized chair model, `chair.binvox` (you can try it on the
 one in the repo).  Here's how it looks in
 [`viewvox`](http://www.cs.princeton.edu/~min/viewvox/):
 
-<img alt="chair" width="600" src="http://github.com/downloads/dimatura/binvox-rw-py/chair.png"></img>
+![chair](https://raw.githubusercontent.com/dimatura/binvox-rw-py/public/chair.png)
 
 Then
 
     >>> import binvox_rw
     >>> with open('chair.binvox', 'rb') as f:
-    ...     model = binvox_rw.read(f)
+    ...     model = binvox_rw.read_as_3d_array(f)
     ...
     >>> model.dims
     [32, 32, 32]
@@ -34,11 +34,11 @@ Then
     array([[[ True, False, False, ..., False, False, False],
             [ True, False, False, ..., False, False, False],
             [ True, False, False, ..., False, False, False],
-            ..., 
+            ...,
            [[False, False, False, ..., False, False, False],
             [False, False, False, ..., False, False, False],
             [False, False, False, ..., False, False, False],
-            ..., 
+            ...,
             [False, False, False, ..., False, False, False],
             [False, False, False, ..., False, False, False],
             [False, False, False, ..., False, False, False]]], dtype=bool)
@@ -47,13 +47,13 @@ You get the idea. `model.data` has the boolean 3D array. You can then
 manipulate however you wish. For example, here we dilate it with
 `scipy.ndimage` and write the dilated version to disk:
 
-    >>> import scipy.ndimage 
+    >>> import scipy.ndimage
     >>> scipy.ndimage.binary_dilation(model.data.copy(), output=model.data)
     >>> model.write('dilated.binvox')
 
 Then we get a fat chair:
 
-<img alt="fat chair" width="600" src="http://github.com/downloads/dimatura/binvox-rw-py/fat_chair.png"></img>
+![fat chair](https://raw.githubusercontent.com/dimatura/binvox-rw-py/public/fat_chair.png)
 
 ## Sparse representation
 
@@ -65,7 +65,7 @@ This is a really simple, 200-line module. You should just stick into whatever
 project you're using.  Or copy it to `/usr/share/lib/pythonX.Y/site-packages`
 if you really want a system-wide installation.
 
---- 
+---
 
 Daniel Maturana
 `dimatura@cmu.edu`

--- a/binvox_rw.py
+++ b/binvox_rw.py
@@ -106,11 +106,11 @@ def read_header(fp):
     """ Read binvox header. Mostly meant for internal use.
     """
     line = fp.readline().strip()
-    if not line.startswith('#binvox'):
+    if not line.startswith(b'#binvox'):
         raise IOError('Not a binvox file')
-    dims = map(int, fp.readline().strip().split(' ')[1:])
-    translate = map(float, fp.readline().strip().split(' ')[1:])
-    scale = map(float, fp.readline().strip().split(' ')[1:])[0]
+    dims = list(map(int, fp.readline().strip().split(b' ')[1:]))
+    translate = list(map(float, fp.readline().strip().split(b' ')[1:]))
+    scale = list(map(float, fp.readline().strip().split(b' ')[1:]))[0]
     line = fp.readline()
     return dims, translate, scale
 


### PR DESCRIPTION
The README didn't mention the renamed `read_as_3d_array` method. And some lines in the header checks were changed due to support Python 3.
