### PR TITLE
Port to Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# binvox-rw-py (pyhon 3)
+# binvox-rw-py (python 3)
 
 Small Python module to read and write `.binvox` files. The voxel data is
 represented as dense 3-dimensional Numpy arrays in Python (a direct if somewhat

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# binvox-rw-py (ptyhon 3)
+# binvox-rw-py (pyhon 3)
 
 Small Python module to read and write `.binvox` files. The voxel data is
 represented as dense 3-dimensional Numpy arrays in Python (a direct if somewhat

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# binvox-rw-py
+# binvox-rw-py (ptyhon 3)
 
 Small Python module to read and write `.binvox` files. The voxel data is
 represented as dense 3-dimensional Numpy arrays in Python (a direct if somewhat
@@ -9,6 +9,8 @@ wasteful representation for sparse models) or as an array of 3D coordinates
 convert 3D models into binary voxel format. The `.binvox` file format is a
 simple run length encoding format described
 [here](http://www.cs.princeton.edu/~min/binvox/binvox.html).
+
+The original version fails to save a file when run with python 3
 
 ## Code example
 


### PR DESCRIPTION
Writing a binvox yields to different results when run with python 3. The current PR fixes the issue and maintains retro compatibility with python 2